### PR TITLE
add date on which 75% of rewards begin to unlock

### DIFF
--- a/lua-frontend/src/views/Farm/components/Harvest.tsx
+++ b/lua-frontend/src/views/Farm/components/Harvest.tsx
@@ -32,7 +32,7 @@ const Harvest: React.FC<HarvestProps> = ({ pid }) => {
               <Value value={getBalanceNumber(earnings)}/>
               <br/>
               <div style={{fontSize: 13, color: 'rgb(255,152,0,0.7)'}}>During the first 8 weeks since launch, <b>25% of your earned LUA</b> is available to <b>unlock immediately</b></div>
-              <div style={{marginTop: 10, fontSize: 13, color: 'rgb(255,152,0,0.7)'}}>Beginning week 17 from launch, the remaining <b>75% will be unlocked</b> linearly every block <b>over 1 year</b>.</div>
+              <div style={{marginTop: 10, fontSize: 13, color: 'rgb(255,152,0,0.7)'}}>Beginning January 18, 2020, the remaining <b>75% will be unlocked</b> linearly every block <b>over 1 year</b>.</div>
             </StyledValue>
           </StyledCardHeader>
           <StyledCardActions>


### PR DESCRIPTION
This was requested multiple times in the LuaSwap telegram channel by myself, Faruk, and Aadi

Please let me know if there is another format that my pull requests should take - I'm happy to conform to code contributing guidelines!  Also LMK if the date is correct.. I did it based on counting the weeks, but I could be wrong. Thanks!